### PR TITLE
Fix FunctionDoc.return_type for lack of description

### DIFF
--- a/pyjsdoc.py
+++ b/pyjsdoc.py
@@ -1088,7 +1088,7 @@ class FunctionDoc(CommentDoc):
         if '{' in ret and '}' in ret:
             if not '}  ' in ret:
                 # Ensure that name is empty
-                ret = ret.replace('} ', '}  ')
+                ret = re.sub(r'\}\s*', '}  ', ret)
             return ParamDoc(ret)
         if ret and type:
             return ParamDoc('{%s}  %s' % (type, ret))


### PR DESCRIPTION
According to the JSDoc documentation, `@returns` may specify only a type
without a description, in which case the final `}` is followed directly
by a newline.

This is not handled correctly by return_type as it replaces `} ` by `}
` and will thus fail to generate empty name and description, erroring in
ParamDoc.__init__ instead.