### PR TITLE
strip_stars does not strip space between star and text

### DIFF
--- a/pyjsdoc.py
+++ b/pyjsdoc.py
@@ -260,7 +260,7 @@ def strip_stars(doc_comment):
     'This is a\n multiline comment.'
 
     """
-    return re.sub('\n\s*?\*\s*?', '\n', doc_comment[3:-2]).strip()
+    return re.sub('\n\s*?\*\s?', '\n', doc_comment[3:-2]).strip()
 
 def split_tag(section):
     """

--- a/pyjsdoc.py
+++ b/pyjsdoc.py
@@ -260,7 +260,7 @@ def strip_stars(doc_comment):
     'This is a\n multiline comment.'
 
     """
-    return re.sub('\n\s*?\*\s?', '\n', doc_comment[3:-2]).strip()
+    return re.sub('\n\s*?\*[\t ]?', '\n', doc_comment[3:-2]).strip()
 
 def split_tag(section):
     """


### PR DESCRIPTION
Because the current pattern is a non-greedy space match *at the end* of
the regex, it's never going to do anything (the regex will always match
with 0 spaces and stop there).

I assume the intent was to remove the (common) space separating the star
and text, removing the repetition should do that. Making the operator
greedy would break e.g. indented examples which probably isn't a good
idea.